### PR TITLE
Fix UI test broken by new nightly compiler error format.

### DIFF
--- a/tests/ui/not-repeatable.stderr
+++ b/tests/ui/not-repeatable.stderr
@@ -21,11 +21,7 @@ note: the traits `Iterator` and `ToTokens` must be implemented
   |
   | pub trait ToTokens {
   | ^^^^^^^^^^^^^^^^^^
-  |
- ::: $RUST/core/src/iter/traits/iterator.rs
-  |
-  | pub trait Iterator {
-  | ^^^^^^^^^^^^^^^^^^
+ --> $RUST/core/src/iter/traits/iterator.rs
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following traits define an item `quote_into_iter`, perhaps you need to implement one of them:
           candidate #1: `ext::RepAsIteratorExt`


### PR DESCRIPTION
The Rust compiler changed the format of an error message.  This updates a UI snapshot test to expect the new format.

Without this change:
<details><summary>Output of `cargo +nightly test` with tests/ui/not-repeatable.rs failing.</summary>

```
user@Users-MacBook-Pro fork-quote % cargo +nightly version
cargo 1.89.0-nightly (64a124607 2025-05-30)
user@Users-MacBook-Pro fork-quote % cargo +nightly test                                                        
   Compiling serde v1.0.219
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling hashbrown v0.15.3
   Compiling equivalent v1.0.2
   Compiling toml_write v0.1.1
   Compiling winnow v0.7.10
   Compiling target-triple v0.1.4
   Compiling serde_json v1.0.140
   Compiling rustversion v1.0.21
   Compiling memchr v2.7.4
   Compiling itoa v1.0.15
   Compiling ryu v1.0.20
   Compiling termcolor v1.4.1
   Compiling dissimilar v1.0.10
   Compiling glob v0.3.2
   Compiling indexmap v2.9.0
   Compiling quote v1.0.40
   Compiling quote v1.0.40 (/Users/user/fork-quote)
   Compiling syn v2.0.101
   Compiling serde_spanned v0.6.8
   Compiling toml_datetime v0.6.9
   Compiling toml_edit v0.22.26
   Compiling serde_derive v1.0.219
   Compiling toml v0.8.22
   Compiling trybuild v1.0.105
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.87s
     Running unittests src/lib.rs (target/debug/deps/quote-f18a509a67f4f421)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/compiletest.rs (target/debug/deps/compiletest-00c318bf97476cf8)

running 1 test
   Compiling proc-macro2 v1.0.95
    Checking unicode-ident v1.0.18
   Compiling rustversion v1.0.21
    Checking quote v1.0.40 (/Users/user/fork-quote)
    Checking quote-tests v0.0.0 (/Users/user/fork-quote/target/tests/trybuild/quote)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.53s


test tests/ui/does-not-have-iter-interpolated-dup.rs ... ok
test tests/ui/does-not-have-iter-interpolated.rs ... ok
test tests/ui/does-not-have-iter-separated.rs ... ok
test tests/ui/does-not-have-iter.rs ... ok
test tests/ui/not-quotable.rs ... ok
test tests/ui/not-repeatable.rs ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0599]: the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not satisfied
 --> tests/ui/not-repeatable.rs:7:13
  |
3 | struct Ipv4Addr;
  | --------------- method `quote_into_iter` not found for this struct because it doesn't satisfy `Ipv4Addr: Iterator`, `Ipv4Addr: ToTokens`, `Ipv4Addr: ext::RepIteratorExt` or `Ipv4Addr: ext::RepToTokensExt`
...
7 |     let _ = quote! { #(#ip)* };
  |             ^^^^^^^^^^^^^^^^^^ method cannot be called on `Ipv4Addr` due to unsatisfied trait bounds
  |
  = note: the following trait bounds were not satisfied:
          `Ipv4Addr: Iterator`
          which is required by `Ipv4Addr: ext::RepIteratorExt`
          `&Ipv4Addr: Iterator`
          which is required by `&Ipv4Addr: ext::RepIteratorExt`
          `Ipv4Addr: ToTokens`
          which is required by `Ipv4Addr: ext::RepToTokensExt`
          `&mut Ipv4Addr: Iterator`
          which is required by `&mut Ipv4Addr: ext::RepIteratorExt`
note: the traits `Iterator` and `ToTokens` must be implemented
 --> src/to_tokens.rs
  |
  | pub trait ToTokens {
  | ^^^^^^^^^^^^^^^^^^
  |
 ::: $RUST/core/src/iter/traits/iterator.rs
  |
  | pub trait Iterator {
  | ^^^^^^^^^^^^^^^^^^
  = help: items from traits can only be used if the trait is implemented and in scope
  = note: the following traits define an item `quote_into_iter`, perhaps you need to implement one of them:
          candidate #1: `ext::RepAsIteratorExt`
          candidate #2: `ext::RepIteratorExt`
          candidate #3: `ext::RepToTokensExt`
  = note: this error originates in the macro `$crate::quote_bind_into_iter` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0599]: the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not satisfied
 --> tests/ui/not-repeatable.rs:7:13
  |
3 | struct Ipv4Addr;
  | --------------- method `quote_into_iter` not found for this struct because it doesn't satisfy `Ipv4Addr: Iterator`, `Ipv4Addr: ToTokens`, `Ipv4Addr: ext::RepIteratorExt` or `Ipv4Addr: ext::RepToTokensExt`
...
7 |     let _ = quote! { #(#ip)* };
  |             ^^^^^^^^^^^^^^^^^^ method cannot be called on `Ipv4Addr` due to unsatisfied trait bounds
  |
  = note: the following trait bounds were not satisfied:
          `Ipv4Addr: Iterator`
          which is required by `Ipv4Addr: ext::RepIteratorExt`
          `&Ipv4Addr: Iterator`
          which is required by `&Ipv4Addr: ext::RepIteratorExt`
          `Ipv4Addr: ToTokens`
          which is required by `Ipv4Addr: ext::RepToTokensExt`
          `&mut Ipv4Addr: Iterator`
          which is required by `&mut Ipv4Addr: ext::RepIteratorExt`
note: the traits `Iterator` and `ToTokens` must be implemented
 --> src/to_tokens.rs
  |
  | pub trait ToTokens {
  | ^^^^^^^^^^^^^^^^^^
 --> $RUST/core/src/iter/traits/iterator.rs
  = help: items from traits can only be used if the trait is implemented and in scope
  = note: the following traits define an item `quote_into_iter`, perhaps you need to implement one of them:
          candidate #1: `ext::RepAsIteratorExt`
          candidate #2: `ext::RepIteratorExt`
          candidate #3: `ext::RepToTokensExt`
  = note: this error originates in the macro `$crate::quote_bind_into_iter` which comes from the expansion of the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
note: If the actual output is the correct output you can bless it by rerunning
      your test with the environment variable TRYBUILD=overwrite

test tests/ui/wrong-type-span.rs ... ok


test ui ... FAILED

failures:

---- ui stdout ----

thread 'ui' panicked at /Users/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trybuild-1.0.105/src/run.rs:102:13:
1 of 7 tests failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    ui

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s

error: test failed, to rerun pass `--test compiletest`
```
</details>

Without this change:
<details><summary>Output of `cargo +nightly test` with all tests passing</summary>

With this change:
```
user@Users-MacBook-Pro fork-quote % cargo +nightly test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/quote-f18a509a67f4f421)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/compiletest.rs (target/debug/deps/compiletest-00c318bf97476cf8)

running 1 test
    Checking quote-tests v0.0.0 (/Users/user/fork-quote/target/tests/trybuild/quote)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s


test tests/ui/does-not-have-iter-interpolated-dup.rs ... ok
test tests/ui/does-not-have-iter-interpolated.rs ... ok
test tests/ui/does-not-have-iter-separated.rs ... ok
test tests/ui/does-not-have-iter.rs ... ok
test tests/ui/not-quotable.rs ... ok
test tests/ui/not-repeatable.rs ... ok
test tests/ui/wrong-type-span.rs ... ok


test ui ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s

     Running tests/test.rs (target/debug/deps/test-7e8c7a6d6671ec64)

running 40 tests
test test_box_str ... ok
test test_array ... ok
test test_btreeset_repetition ... ok
test test_c_string ... ok
test test_append_tokens ... ok
test test_c_str ... ok
test test_char ... ok
test test_closure ... ok
test test_advanced ... ok
test test_duplicate ... ok
test test_cow ... ok
test test_duplicate_name_repetition ... ok
test test_duplicate_name_repetition_no_copy ... ok
test test_empty_quote ... ok
test test_fancy_repetition ... ok
test test_floating ... ok
test test_format_ident ... ok
test test_format_ident_strip_raw ... ok
test test_ident ... ok
test test_inner_attr ... ok
test test_inner_block_comment ... ok
test test_inner_line_comment ... ok
test test_integer ... ok
test test_interpolated_literal ... ok
test test_iter ... ok
test test_nested_fancy_repetition ... ok
test test_nonrep_in_repetition ... ok
test test_outer_attr ... ok
test test_outer_block_comment ... ok
test test_outer_line_comment ... ok
test test_quote_raw_id ... ok
test test_quote_impl ... ok
test test_quote_spanned_impl ... ok
test test_star_after_repetition ... ok
test test_str ... ok
test test_string ... ok
test test_substitution ... ok
test test_type_inference_for_span ... ok
test test_underscore ... ok
test test_variable_name_conflict ... ok

test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests quote

running 22 tests
test src/lib.rs - quote (line 556) ... ok
test src/lib.rs - quote (line 733) - compile fail ... ok
test src/lib.rs - quote (line 741) - compile fail ... ok
test src/lib.rs - (line 48) ... ok
test src/lib.rs - quote (line 778) - compile fail ... ok
test src/lib.rs - quote (line 602) ... ok
test src/format.rs - format::format_ident (line 54) ... ok
test src/lib.rs - quote (line 660) ... ok
test src/lib.rs - quote (line 626) ... ok
test src/lib.rs - quote (line 700) ... ok
test src/lib.rs - quote (line 715) ... ok
test src/lib.rs - quote (line 682) ... ok
test src/format.rs - format::format_ident (line 78) ... ok
test src/ext.rs - ext::TokenStreamExt::append_all (line 18) ... ok
test src/lib.rs - quote (line 643) ... ok
test src/format.rs - format::format_ident (line 91) ... ok
test src/format.rs - format::format_ident (line 43) ... ok
test src/lib.rs - quote (line 750) ... ok
test src/lib.rs - quote (line 788) ... ok
test src/lib.rs - quote_spanned (line 641) ... ok
test src/lib.rs - quote_spanned (line 682) ... ok
test src/to_tokens.rs - to_tokens::ToTokens::to_tokens (line 20) ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.78s
```
</details>